### PR TITLE
Update EEex.tp2

### DIFF
--- a/EEex/EEex.tp2
+++ b/EEex/EEex.tp2
@@ -10,10 +10,21 @@ REQUIRE_PREDICATE (
 	OR (GAME_IS ~iwdee~)
 ) ~Game not supported.~
 
+	ACTION_FOR_EACH file IN ACTION OBJECT TRIGGER BEGIN
+		COPY ~EEex\patches\%file%.IDS~ ~EEex\patches~
+			COUNT_2DA_ROWS 2 rows
+			FOR (i = 0; i <= rows; ++i) BEGIN
+				READ_2DA_ENTRY i 0 2 "col1"
+				READ_2DA_ENTRY i 1 2 "col2"
+				DEFINE_ASSOCIATIVE_ARRAY EEex_append_array BEGIN ~%file%~ , ~%col1%~ , ~%col2%~ => ~~ END
+			END
+		BUT_ONLY
+	END
+	ACTION_PHP_EACH EEex_append_array AS data => ~~ BEGIN
+		APPEND ~%data%.IDS~ ~%data_1% %data_2%~ UNLESS ~^%data_1% ~
+	END
+
 	COPY_EXISTING ~UI.MENU~ ~override~ INSERT_FILE 0 ~EEex\patches\UI.MENU~ IF_EXISTS
-	COPY_EXISTING ~ACTION.IDS~ ~override~ APPEND_FILE ~EEex\patches\ACTION.IDS~ IF_EXISTS
-	COPY_EXISTING ~OBJECT.IDS~ ~override~ APPEND_FILE ~EEex\patches\OBJECT.IDS~ IF_EXISTS
-	COPY_EXISTING ~TRIGGER.IDS~ ~override~ APPEND_FILE ~EEex\patches\TRIGGER.IDS~ IF_EXISTS
 
 	COPY ~EEex\loader~ ~.~ IF_EXISTS
 	COPY ~EEex\copy~ ~override~ IF_EXISTS


### PR DESCRIPTION
Due to frequent updates it's more convenient to install EEex at the end. The ids stuff may be needed by mods installed earlier in order to compile scripts, though. This code will skip ids appending of each row if the row has been already appended by some previously installed mod.