### PR TITLE
Some fixes and changes to EEex_Pro

### DIFF
--- a/EEex/copy/EEex_Opc.lua
+++ b/EEex/copy/EEex_Opc.lua
@@ -252,7 +252,7 @@ EEex_AddScreenEffectsGlobal("EXEFFMOD", function(effectData, creatureData)
 
 
 		local new_damage_type = EEex_GetActorStat(sourceID, 617)
-		if new_damage_type ~= 0 and restype == 0 and parent_resource == "" then
+		if new_damage_type ~= 0 and restype == 0 and parent_resource == "EEEX_DAM" then
 			damage_type = new_damage_type - 1
 			EEex_WriteWord(effectData + 0x1E, damage_type)
 		end


### PR DESCRIPTION
*Type Mutator and Projectile Mutator functions are now passed the spell's resref (though I was unable to find where the resref is stored for sources >= 6).
*Effect Mutator functions are now passed the correct actor share.
*The EXMODSMP function should work correctly in all areas (previously it got messed up if the area's search map width was not divisible by 8).
*EEex_IterateActorIDs() no longer crashes the game.