### PR TITLE
[op333] Static Charge

### DIFF
--- a/EEex/EEex.tp2
+++ b/EEex/EEex.tp2
@@ -1,6 +1,6 @@
 BACKUP ~EEex/backup~
 AUTHOR ~Bubb~
-VERSION ~v0.9.22-alpha~
+VERSION ~master~
 README ~EEex/readme-EEex.html~
 
 BEGIN ~EEex~

--- a/EEex/copy/EEex_Opcode.lua
+++ b/EEex/copy/EEex_Opcode.lua
@@ -208,6 +208,16 @@ function EEex_Opcode_Hook_ApplySpell_ShouldFlipSplprotSourceAndTarget(effect)
 	return EEex_IsBitSet(effect.m_special, 1)
 end
 
+-------------------------------------------------------------------------------------------------
+-- Opcode #333 (param3 BIT0 allows "SPL" file not to terminate upon a successful saving throw) --
+-------------------------------------------------------------------------------------------------
+
+function EEex_Opcode_Hook_OnOp333CopiedSelf(effect)
+	if EEex_IsBitSet(effect.m_effectAmount2, 0) then
+		effect.m_savingThrow = 0
+	end
+end
+
 --------------------------------------------
 -- New Opcode #400 (SetTemporaryAIScript) --
 --------------------------------------------

--- a/EEex/copy/EEex_Opcode_Patch.lua
+++ b/EEex/copy/EEex_Opcode_Patch.lua
@@ -360,6 +360,29 @@
 		]]},
 	}))
 
+	-------------------------------------------------------------------------------------------------
+	-- Opcode #333 (param3 BIT0 allows "SPL" file not to terminate upon a successful saving throw) --
+	-------------------------------------------------------------------------------------------------
+
+	EEex_HookAfterRestore(0x1401C7DBA, 0, 9, 9, EEex_FlattenTable({
+		{[[
+			#MAKE_SHADOW_SPACE(56)
+			mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)], rax
+			mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-16)], rdx
+		]]},
+		EEex_GenLuaCall("EEex_Opcode_Hook_OnOp333CopiedSelf", {
+			["args"] = {
+				function(rspOffset) return {"mov qword ptr ss:[rsp+#$(1)], rax #ENDL", {rspOffset}}, "CGameEffect" end,
+			},
+		}),
+		{[[
+			call_error:
+			mov rdx, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-16)]
+			mov rax, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)]
+			#DESTROY_SHADOW_SPACE
+		]]},
+	}))
+
 	-----------------
 	-- New Opcodes --
 	-----------------

--- a/EEex/copy/EEex_Opcode_Patch.lua
+++ b/EEex/copy/EEex_Opcode_Patch.lua
@@ -364,7 +364,7 @@
 	-- Opcode #333 (param3 BIT0 allows "SPL" file not to terminate upon a successful saving throw) --
 	-------------------------------------------------------------------------------------------------
 
-	EEex_HookAfterRestore(0x1401C7DBA, 0, 9, 9, EEex_FlattenTable({
+	EEex_HookAfterRestore(EEex_Label("Hook-CGameEffectStaticCharge::ApplyEffect()-CopyOp333Call"), 0, 9, 9, EEex_FlattenTable({
 		{[[
 			#MAKE_SHADOW_SPACE(56)
 			mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)], rax

--- a/EEex/loader/InfinityLoader.db
+++ b/EEex/loader/InfinityLoader.db
@@ -1217,6 +1217,9 @@ Operations=ADD -43
 Pattern=488D8FC81C0000
 Operations=ADD 20
 
+[Hook-CGameEffectStaticCharge::ApplyEffect()-CopyOp333Call]
+Pattern=FF50088B9350010000
+
 [Hook-CGameObjectArray::Clean()-DestructJmp]
 Pattern=6666660F1F840000000000480FBFC2
 Operations=ADD 32

--- a/package_mod.bat
+++ b/package_mod.bat
@@ -6,7 +6,7 @@ call "%~dp0..\ModPackaging\utilities\ie_games.bat"
 
 REM /* MODIFY: set the values of the 3 variables below to reflect the current mod version */
 set "mod_name=EEex"
-set "mod_version=v0.9.22-alpha"
+set "mod_version=master"
 set mod_folder=EEex
 
 REM /* MODIFY: list here which IE games the mod is compatible with, from this list of possibilities: */


### PR DESCRIPTION
As of now, its Saving Throw is checked EVERY time it triggers, terminating the `op333` effect if successful, so unless that is desired (or it only triggers once), it should not have a Saving Throw.

The following PR enables `BIT0` of `param3` to bypass this issue (i.e., when `op333` is used in an external `EFF` file, setting `BIT0` of `param3` to `1` allows the specified `SPL` file not to terminate upon a successful saving throw).