### PR TITLE
New Engine Feature: Expanded capabilities for op146/148

### DIFF
--- a/EEex/copy/EEex_Opcode_Patch.lua
+++ b/EEex/copy/EEex_Opcode_Patch.lua
@@ -149,6 +149,79 @@
 	})
 
 	--[[
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	| Opcodes #146 / #148                                                                                                                    |
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	|   (special & 1) != 0 and param2 == 0 -> Queue SpellNoDec() / SpellPointNoDec() instead of ForceSpell() / ForceSpellPoint()                 |
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	|   These hooks intentionally run in the param2 == 0 branch's *late* action-copy sequence, rather than at the earlier engine constant load.  |
+	|   Earlier hook sites looked simpler, but they sit farther away from the final CAIAction write and rely on transient register state.        |
+	|   The sites below are immediately before the outgoing action ID is copied into the message object's embedded CAIAction.                    |
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	|   CGameEffectCastSpell::ApplyEffect()                                                                                                      |
+	|       entry mapping:                                                                                                                       |
+	|           rcx = this (effect)                                                                                                              |
+	|           rdx = sprite                                                                                                                     |
+	|       working registers in the param2 == 0 path:                                                                                           |
+	|           rsi = this                                                                                                                       |
+	|           r15 = sprite                                                                                                                     |
+	|       late copy sequence chosen for the hook:                                                                                              |
+	|           0x1401A85EB  movzx eax, word ptr [rsp+60h]                                                                                       |
+	|           0x1401A85F0  lea   rcx, [r14+18h]                                                                                                |
+	|           0x1401A85F4  mov   word ptr [r14+10h], ax                                                                                        |
+	|       The hook restores the load + lea, then overwrites eax only when this->m_special bit0 is set.                                         |
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	|   CGameEffectCastSpellPoint::ApplyEffect()                                                                                                 |
+	|       entry mapping:                                                                                                                       |
+	|           rcx = this (effect)                                                                                                              |
+	|           rdx = sprite                                                                                                                     |
+	|       working registers in the param2 == 0 path:                                                                                           |
+	|           rdi = this                                                                                                                       |
+	|           r14 = sprite                                                                                                                     |
+	|       late copy sequence chosen for the hook:                                                                                              |
+	|           0x1401A8847  movzx eax, word ptr [rbp-59h]                                                                                       |
+	|           0x1401A884B  lea   rcx, [rsi+18h]                                                                                                |
+	|           0x1401A884F  mov   word ptr [rsi+10h], ax                                                                                        |
+	|       The hook restores the load + lea, then overwrites eax only when this->m_special bit0 is set.                                         |
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	|   Why `EEex_HookAfterRestoreWithLabels()`?                                                                                                 |
+	|       1) These hook sites are inline instruction streams, not calls or jumps, so the call / conditional-jump helpers do not fit.           |
+	|       2) We want vanilla behavior by default: the engine should still execute its original `movzx ...` and `lea ...` pair first.           |
+	|       3) Only after those bytes run do we want to *optionally* replace the action ID in eax, immediately before the final `mov ..., ax`.   |
+	|       4) `restoreSize` is therefore the exact size of the instructions that must still execute before our conditional override runs:       |
+	|              op146: 9 bytes = 5-byte `movzx eax, word ptr [rsp+60h]` + 4-byte `lea rcx, [r14+18h]`                                         |
+	|              op148: 8 bytes = 4-byte `movzx eax, word ptr [rbp-59h]` + 4-byte `lea rcx, [rsi+18h]`                                         |
+	|       5) The `WithLabels` variant is used so the hook can pass `hook_integrity_watchdog_ignore_registers` through labelPairs.              |
+	+--------------------------------------------------------------------------------------------------------------------------------------------+
+	--]]
+
+	----------------------------------------------------------------
+	-- CGameEffectCastSpell::ApplyEffect() - late action ID copy  --
+	----------------------------------------------------------------
+
+	EEex_HookAfterRestoreWithLabels(EEex_Label("Hook-CGameEffectCastSpell::ApplyEffect()-SetActionId"), 0, 9, 9, {
+		{"hook_integrity_watchdog_ignore_registers", {EEex_HookIntegrityWatchdogRegister.RAX}}}, {[[
+			test dword ptr ds:[rsi+48h], 1 ; this->m_special & 1 ?
+			jz #L(return)                  ; no  -> keep the engine's ForceSpell action ID already restored into eax
+
+			mov eax, 191                   ; yes -> swap the word about to be copied into the outgoing CAIAction to SPELLNODEC
+		]]}
+	)
+
+	---------------------------------------------------------------------
+	-- CGameEffectCastSpellPoint::ApplyEffect() - late action ID copy  --
+	---------------------------------------------------------------------
+
+	EEex_HookAfterRestoreWithLabels(EEex_Label("Hook-CGameEffectCastSpellPoint::ApplyEffect()-SetActionId"), 0, 8, 8, {
+		{"hook_integrity_watchdog_ignore_registers", {EEex_HookIntegrityWatchdogRegister.RAX}}}, {[[
+			test dword ptr ds:[rdi+48h], 1 ; this->m_special & 1 ?
+			jz #L(return)                  ; no  -> keep the engine's ForceSpellPoint action ID already restored into eax
+
+			mov eax, 192                   ; yes -> swap the word about to be copied into the outgoing CAIAction to SPELLPOINTNODEC
+		]]}
+	)
+
+	--[[
 	+------------------------------------------------------------------------------------------------------------------------------------------+
 	| Opcode #248                                                                                                                              |
 	+------------------------------------------------------------------------------------------------------------------------------------------+

--- a/EEex/loader/InfinityLoader.db
+++ b/EEex/loader/InfinityLoader.db
@@ -1807,6 +1807,43 @@ Operations=ADD 23
 Pattern=3881F81000007407
 Operations=ADD 56
 
+[Hook-CGameEffectCastSpell::ApplyEffect()-SetActionId]
+; Pattern derivation:
+;   1) Disassemble the param2 == 0 path and identify the exact instruction where the final action ID is loaded into eax.
+;   2) Start the byte pattern at that target instruction and keep extending forward until the byte sequence is unique in icewind.exe.
+;   3) Because the unique match already begins at the desired hook address (0x1401A85EB), no Operations adjustment is needed.
+;   4) The resulting bytes correspond to:
+;          movzx eax, word ptr [rsp+60h]
+;          lea   rcx, [r14+18h]
+;          mov   word ptr [r14+10h], ax
+; param2 == 0 path, late action-ID copy:
+;   0x1401A85EB  movzx eax, word ptr [rsp+60h]
+;   0x1401A85F0  lea   rcx, [r14+18h]
+;   0x1401A85F4  mov   word ptr [r14+10h], ax
+; The Lua hook restores the load + lea, then conditionally swaps eax before the final store.
+Pattern=0FB7442460498D4E186641894610488D542468
+
+[Hook-CGameEffectCastSpellPoint::ApplyEffect()-SetActionId]
+; Pattern derivation:
+;   1) The ideal hook address is 0x1401A8847 (`movzx eax, word ptr [rbp-59h]`), immediately before the final action-ID store.
+;   2) The byte sequence starting there was not unique in icewind.exe, so the search window was extended backward to include the
+;      preceding constructor call at 0x1401A8842.
+;   3) That longer sequence is unique, but it begins 5 bytes before the desired hook address.
+;   4) `Operations=ADD 5` compensates for that, moving the resolved label from the start of the matched pattern to 0x1401A8847.
+;   5) The resulting bytes cover:
+;          call  CAIAction::CAIAction()
+;          movzx eax, word ptr [rbp-59h]
+;          lea   rcx, [rsi+18h]
+;          mov   word ptr [rsi+10h], ax
+; param2 == 0 path, late action-ID copy:
+;   0x1401A8842  call  CAIAction::CAIAction()
+;   0x1401A8847  movzx eax, word ptr [rbp-59h]
+;   0x1401A884B  lea   rcx, [rsi+18h]
+;   0x1401A884F  mov   word ptr [rsi+10h], ax
+; Pattern starts at the constructor call and ADD 5 lands on the movzx at 0x1401A8847.
+Pattern=E8B9E4F6FF0FB745A7488D4E1866894610488D55AF8B45F7894660
+Operations=ADD 5
+
 [Hook-CGameEffectForceSurge::ApplyEffect()-FirstInstruction]
 Pattern=898248130000
 Operations=ADD -3


### PR DESCRIPTION
`(special & 1) != 0 and param2 == 0` -> Queue `SpellNoDec()` / `SpellPointNoDec()` instead of `ForceSpell()` / `ForceSpellPoint()` .

This small tweak simply allows modders to make sure casting spells from scrolls can be interrupted by damage.

Feature tested on: **IWD:EE** `v2.6.6.0`.