### PR TITLE
Engine Fix: Fix bugged SPEED column in WSPECIAL.2DA

### DIFF
--- a/EEex/copy/EEex_Sprite.lua
+++ b/EEex/copy/EEex_Sprite.lua
@@ -1490,6 +1490,63 @@ function EEex_Sprite_Hook_OnSetCurrAction(sprite)
 	spriteAux["EEex_Sprite_DamageEntriesSinceActionStarted"] = {}
 end
 
+-----------------------------------------------------------
+-- Resolve WSPECIAL.2DA SPEED bonuses for mastery hooks  --
+-----------------------------------------------------------
+
+EEex_Sprite_Private_WSpecialSpeedBonusData = nil
+
+local function EEex_Sprite_Private_GetWSpecialSpeedBonusData()
+
+	local speedBonusData = EEex_Sprite_Private_WSpecialSpeedBonusData
+	if speedBonusData ~= nil then
+		return speedBonusData
+	end
+
+	speedBonusData = {
+		["default"] = 0,
+		["byProficiency"] = {},
+	}
+
+	local wspecial = EEex_Resource_Load2DA("WSPECIAL")
+	local defaultSpeed = tonumber(wspecial:getDefault(), 10) or 0
+	-- Match the engine's STYLBONU path exactly: the table stores negative
+	-- SPEED entries, and CheckCombatStats() subtracts that raw value from
+	-- m_nPhysicalSpeed, which turns a negative 2DA entry into a positive
+	-- accumulated speed modifier on the sprite.
+	speedBonusData.default = defaultSpeed
+
+	local speedColumn = wspecial:findColumnLabel("SPEED")
+	if speedColumn >= 0 then
+		local _, lastRowIndex = wspecial:getMaxIndices()
+		for rowIndex = 0, lastRowIndex do
+			local proficiencyLevel = tonumber(wspecial:getRowLabel(rowIndex), 10)
+			if proficiencyLevel ~= nil then
+				local speedBonus = tonumber(wspecial:getAtPoint(speedColumn, rowIndex), 10) or defaultSpeed
+				speedBonusData.byProficiency[proficiencyLevel] = speedBonus
+			end
+		end
+	end
+
+	EEex_Sprite_Private_WSpecialSpeedBonusData = speedBonusData
+	return speedBonusData
+end
+
+function EEex_Sprite_Hook_GetWeaponMasterySpeedBonus(proficiencyLevel, offHand)
+
+	-- The engine stores a single speed-factor modifier on the sprite while
+	-- CheckCombatStatsWeapon() is invoked once per hand. Apply the WSPECIAL
+	-- bonus only on the primary-hand pass to avoid double-counting the same
+	-- mastery row into the shared accumulator.
+	if offHand or proficiencyLevel == nil or proficiencyLevel < 0 then
+		return 0
+	end
+
+	local speedBonusData = EEex_Sprite_Private_GetWSpecialSpeedBonusData()
+	local speedBonus = speedBonusData.byProficiency[proficiencyLevel]
+	return speedBonus ~= nil and speedBonus or speedBonusData.default
+end
+
 --------------------------------------------------------------------------------------------
 -- Allow ITM header flag BIT18 to ignore weapon styles (as if the item were in SLOT_FIST) --
 --------------------------------------------------------------------------------------------

--- a/EEex/copy/EEex_Sprite_Patch.lua
+++ b/EEex/copy/EEex_Sprite_Patch.lua
@@ -642,6 +642,81 @@
 	})
 
 	--[[
+	+----------------------------------------------------------------------------------------------------------------------------------+
+	| Fix the missing WSPECIAL.2DA[SPEED] mastery bonus in CGameSprite::CheckCombatStatsWeapon()                                       |
+	+----------------------------------------------------------------------------------------------------------------------------------+
+	|   [Lua] EEex_Sprite_Hook_GetWeaponMasterySpeedBonus(proficiencyLevel: number, offHand: boolean) -> number                        |
+	|                                                                                                                                  |
+	|       return:                                                                                                                    |
+	|           -> raw WSPECIAL.2DA SPEED value to subtract from the sprite's shared speed-factor modifier                             |
+	+----------------------------------------------------------------------------------------------------------------------------------+
+	|                                                                                                                                  |
+	| Hook strategy:                                                                                                                   |
+	|   Use EEex_HookAfterRestoreWithLabels() because we need the engine's                                                             |
+	|   final resolved proficiency in r12w after the overwritten instruction                                                           |
+	|   has already run, but before the surrounding WSPECIAL lookup logic                                                              |
+	|   consumes that state. A before-hook would have to manually replay the                                                           |
+	|   displaced instruction stream, and a call hook would sit too early in                                                           |
+	|   the control flow before CheckCombatStatsWeapon() has selected the                                                              |
+	|   effective proficiency level shared by the later bonus code.                                                                    |
+	+----------------------------------------------------------------------------------------------------------------------------------+
+	--]]
+
+	EEex_HookAfterRestoreWithLabels(EEex_Label("Hook-CGameSprite::CheckCombatStatsWeapon()-ApplyMasterySpeedFactor"), 0, 8, 8, {
+		{"hook_integrity_watchdog_ignore_registers", {
+			EEex_HookIntegrityWatchdogRegister.RAX, EEex_HookIntegrityWatchdogRegister.RCX, EEex_HookIntegrityWatchdogRegister.RDX,
+			EEex_HookIntegrityWatchdogRegister.R8, EEex_HookIntegrityWatchdogRegister.R9, EEex_HookIntegrityWatchdogRegister.R10,
+			EEex_HookIntegrityWatchdogRegister.R11
+		}}},
+		EEex_FlattenTable({
+			{[[
+				#MAKE_SHADOW_SPACE(64)
+				; rcx / rdx remain live in the original block after the hook returns.
+				; Save them explicitly because EEex_GenLuaCall() is free to clobber
+				; caller-saved registers.
+				mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)], rcx
+				mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-16)], rdx
+			]]},
+			EEex_GenLuaCall("EEex_Sprite_Hook_GetWeaponMasterySpeedBonus", {
+				["args"] = {
+					function(rspOffset) return {[[
+						; r12w holds the final proficiency level selected by the engine
+						; for the current weapon pass at this point in the function.
+						movsx rax, r12w
+						mov qword ptr ss:[rsp+#$(1)], rax ]], {rspOffset}, [[ #ENDL
+					]]} end,
+					function(rspOffset) return {[[
+						; Read the current stack frame's offHand flag instead of
+						; inferring from equipment state in Lua.
+						mov eax, dword ptr ss:[rbp+0x50]
+						mov qword ptr ss:[rsp+#$(1)], rax ]], {rspOffset}, [[ #ENDL
+					]]}, "boolean" end,
+				},
+				["returnType"] = EEex_LuaCallReturnType.Number,
+			}),
+			{[[
+				jmp no_error
+
+				call_error:
+				xor eax, eax
+
+				no_error:
+				test eax, eax
+				je done
+
+				; Mirror the engine's style-speed path: subtract the raw 2DA value
+				; from m_nPhysicalSpeed so negative rows increase the accumulator.
+				sub word ptr ds:[r14+0x11F2], ax
+
+				done:
+				mov rcx, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)]
+				mov rdx, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-16)]
+				#DESTROY_SHADOW_SPACE
+			]]},
+		})
+	)
+
+	--[[
 	+---------------------------------------------------------------------------------------------------------------------------------+
 	| Implement X-CLSERG.2DA - Ignore the -8 thac0 penalty characters incur when meleeing with a ranged weapon for specific           |
 	| [KITLIST.2DA]->ROWNAME / ITEMCAT.IDS pairs                                                                                      |

--- a/EEex/loader/InfinityLoader.db
+++ b/EEex/loader/InfinityLoader.db
@@ -1869,6 +1869,10 @@ Operations=ADD 7
 Pattern=48894DEF48894DE7
 Operations=ADD 17
 
+[Hook-CGameSprite::CheckCombatStatsWeapon()-ApplyMasterySpeedFactor]
+Pattern=0FBF0D402A2500410FBF9530150000410FBFDC3BCA7D2B
+Operations=ADD 7
+
 [Hook-CGameSprite::CheckIfVisible()-FirstInstruction]
 Pattern=B8B8110000
 Operations=ADD -30


### PR DESCRIPTION
The `SPEED` column in `WSPECIAL.2DA` is no longer ignored by the engine — High Mastery and Grand Mastery do now provide bonuses to speed factor as they should.

Fix tested on: **IWD:EE** `v2.6.6.0`.