### PR TITLE
New Engine Feature: Softcode op219 bonus

### DIFF
--- a/EEex/copy/EEex_Opcode.lua
+++ b/EEex/copy/EEex_Opcode.lua
@@ -159,6 +159,23 @@ function EEex_Opcode_Hook_OnOp214ApplyEffect(effect, sprite)
 	return true
 end
 
+----------------------------------------------------
+-- Opcode 0xDB (param3 overrides hardcoded bonus) --
+----------------------------------------------------
+
+function EEex_Opcode_Hook_OnOp219ApplyEffect(effect, selectiveBonus)
+
+	-- `m_effectAmount2` is the caller-controlled override value. Treat it as a signed
+	-- integer and only apply it when non-zero so that `0` continues to mean "keep the
+	-- engine default", which is the hardcoded +2 written just before this hook runs.
+	local effectAmount2 = effect.m_effectAmount2
+	if effectAmount2 ~= 0 then
+		-- Overwrite only the computed bonus magnitude. The selector / CAIObjectType
+		-- portion of the bonus has already been populated by the engine.
+		selectiveBonus.m_bonus = effectAmount2
+	end
+end
+
 ------------------------------------------------------------
 -- Opcode #248 (Special BIT0 allows .EFF to bypass op120) --
 ------------------------------------------------------------

--- a/EEex/copy/EEex_Opcode_Patch.lua
+++ b/EEex/copy/EEex_Opcode_Patch.lua
@@ -149,6 +149,67 @@
 	})
 
 	--[[
+	+--------------------------------------------------------------------------------------------------------+
+	| Opcode 0xDB (CGameEffectProtectionCircle)                                                              |
+	+--------------------------------------------------------------------------------------------------------+
+	|   m_effectAmount2 != 0 -> Override the engine's hardcoded protection bonus with m_effectAmount2        |
+	+--------------------------------------------------------------------------------------------------------+
+	|   [Lua] EEex_Opcode_Hook_OnOp219ApplyEffect(effect: CGameEffect, selectiveBonus: CSelectiveBonus)      |
+	+--------------------------------------------------------------------------------------------------------+
+	|   This hook is placed on the exact engine instruction that stores the hardcoded `2` into               |
+	|   `CSelectiveBonus::m_bonus`.                                                                          |
+	|                                                                                                        |
+	|   Use `EEex_HookAfterRestoreWithLabels()` specifically because:                                        |
+	|     1. We want the engine's original store to run first, so the default behavior stays intact when     |
+	|        `m_effectAmount2 == 0`.                                                                         |
+	|     2. At this point in `ApplyEffect()`, `rdi` already points at the freshly constructed               |
+	|        `CSelectiveBonus`, so Lua can safely overwrite only `m_bonus` without reconstructing anything.  |
+	|     3. `AfterRestore` automatically replays the overwritten bytes before our hook body runs, which     |
+	|        is cleaner and less brittle than manually re-emitting the instruction in a `BeforeRestore`      |
+	|        hook.                                                                                           |
+	+--------------------------------------------------------------------------------------------------------+
+	--]]
+
+	EEex_HookAfterRestoreWithLabels(EEex_Label("Hook-CGameEffectProtectionCircle::ApplyEffect()-SetHardcodedBonus"), 0, 7, 7, {
+		{"hook_integrity_watchdog_ignore_registers", {
+			EEex_HookIntegrityWatchdogRegister.RAX, EEex_HookIntegrityWatchdogRegister.RCX, EEex_HookIntegrityWatchdogRegister.RDX,
+			EEex_HookIntegrityWatchdogRegister.R8, EEex_HookIntegrityWatchdogRegister.R9, EEex_HookIntegrityWatchdogRegister.R10,
+			EEex_HookIntegrityWatchdogRegister.R11
+		}}},
+		EEex_FlattenTable({
+			{[[
+				; The overwritten 7-byte engine store has already been restored / executed by
+				; EEex_HookAfterRestoreWithLabels() before control reaches this assembly.
+				; Register state at this site:
+				;   rbx -> CGameEffectProtectionCircle* / CGameEffect*
+				;   rdi -> CSelectiveBonus*
+				;
+				; Save the registers we reuse for the Lua call. If Lua errors, we simply
+				; restore them and fall through, leaving the engine's original +2 in place.
+				#MAKE_SHADOW_SPACE(64)
+				mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)], rcx
+				mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-16)], rdi
+			]]},
+			EEex_GenLuaCall("EEex_Opcode_Hook_OnOp219ApplyEffect", {
+				["args"] = {
+					-- `rbx` still holds the effect that is currently applying.
+					function(rspOffset) return {"mov qword ptr ss:[rsp+#$(1)], rbx #ENDL", {rspOffset}}, "CGameEffect" end,
+					-- `rdi` points at the just-created selective bonus whose `m_bonus`
+					-- field the engine has already initialized to 2.
+					function(rspOffset) return {"mov qword ptr ss:[rsp+#$(1)], rdi #ENDL", {rspOffset}}, "CSelectiveBonus" end,
+				},
+			}),
+			{[[
+				call_error:
+				; On failure, restore volatile state and continue with the engine's default bonus.
+				mov rdi, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-16)]
+				mov rcx, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)]
+				#DESTROY_SHADOW_SPACE
+			]]},
+		})
+	)
+
+	--[[
 	+------------------------------------------------------------------------------------------------------------------------------------------+
 	| Opcode #248                                                                                                                              |
 	+------------------------------------------------------------------------------------------------------------------------------------------+

--- a/EEex/loader/InfinityLoader.db
+++ b/EEex/loader/InfinityLoader.db
@@ -1835,6 +1835,10 @@ Operations=ADD -43
 Pattern=488D8FC81C0000
 Operations=ADD 20
 
+[Hook-CGameEffectProtectionCircle::ApplyEffect()-SetHardcodedBonus]
+Pattern=488D8E001D0000C7471802000000488BD7
+Operations=ADD 7
+
 [Hook-CGameEffectSecondaryCastList::ApplyEffect()]
 Pattern=48895C24185556574154415541564157488D6C24D94881EC00010000
 


### PR DESCRIPTION
Modders can now overwrite the hardcoded `2` point bonus AC and Saving Throws against the creature type specified by setting a non-zero `parameter3` (negative integers/maluses supported).

Feature tested on **IWD:EE** `v2.6.6.0`.