### PR TITLE
Engine Fix: op33*p2=3 modifies instantly SAVEVSWANDS instead of SAVEVSDEATH

### DIFF
--- a/EEex/copy/EEex_Opcode_Patch.lua
+++ b/EEex/copy/EEex_Opcode_Patch.lua
@@ -86,6 +86,32 @@
 	--------------------------------------
 
 	--[[
+	+------------------------------------------------------------------------------------------------------------------------------------+
+	| Opcode #33                                                                                                                         |
+	+------------------------------------------------------------------------------------------------------------------------------------+
+	|   BUG: v2.5+ - param2 == 3 immediately subtracts from SAVEVSWANDS instead of SAVEVSDEATH in the current effect pass                |
+	+------------------------------------------------------------------------------------------------------------------------------------+
+	|   Loader label: Hook-CGameEffectSaveVsDeath::ApplyEffect()-ImmediateSaveWrite                                                      |
+	|       -> resolves to the first byte of the buggy 7-byte write instruction                                                          |
+	|          `sub word ptr [rdi+1136h], ax`                                                                                            |
+	|                                                                                                                                    |
+	|   Why EEex_HookNOPs() here:                                                                                                        |
+	|       -> this site is a single in-place instruction, not a call boundary                                                           |
+	|       -> we do not need to preserve any original bytes or re-enter the displaced instruction                                       |
+	|       -> the bad instruction is exactly 7 bytes long, so EEex_HookNOPs(..., 2, ...) is a perfect fit:                              |
+	|          the helper writes a 5-byte jump over the site and pads the remaining 2 bytes with NOPs                                    |
+	|       -> that makes this the narrowest patch possible and avoids a broader ApplyEffect hook                                        |
+	+------------------------------------------------------------------------------------------------------------------------------------+
+	--]]
+
+	-- Replace only the incorrect immediate save target:
+	--   engine bug:  sub word ptr ds:[rdi+1136h], ax  ; SAVEVSWANDS
+	--   fixed to:    sub word ptr ds:[rdi+1134h], ax  ; SAVEVSDEATH
+	EEex_HookNOPs(EEex_Label("Hook-CGameEffectSaveVsDeath::ApplyEffect()-ImmediateSaveWrite"), 2, {[[
+		sub word ptr ds:[rdi+1134h], ax
+	]]})
+
+	--[[
 	+--------------------------------------------------------------------------------------------------+
 	| Opcode #214                                                                                      |
 	+--------------------------------------------------------------------------------------------------+

--- a/EEex/loader/InfinityLoader.db
+++ b/EEex/loader/InfinityLoader.db
@@ -1811,6 +1811,16 @@ Operations=ADD 56
 Pattern=898248130000
 Operations=ADD -3
 
+; CGameEffectSaveVsDeath::ApplyEffect(), m_dWFlags == 3 immediate path.
+; The pattern intentionally spans the surrounding branch and state reset so the label resolves
+; to the exact buggy write and not just any similar `sub word ptr [rdi+imm], ax`.
+; `Operations=ADD 18` lands on:
+;   66 29 87 36 11 00 00    sub word ptr [rdi+1136h], ax
+; The Lua hook then replaces only that instruction with the correct SAVEVSDEATH displacement.
+[Hook-CGameEffectSaveVsDeath::ApplyEffect()-ImmediateSaveWrite]
+Pattern=3993CC00000074110FB7431C8993CC00000066298736110000837B24010F852E
+Operations=ADD 18
+
 [Hook-CGameEffectList::Marshal()-OverrideSize]
 Pattern=488BCBFF504085C0
 Operations=ADD 269


### PR DESCRIPTION
Since at least `v2.5`, `param2 == 3` modifies instantly `SAVEVSWANDS` instead of `SAVEVSDEATH`.
As a result, saving throws for effects in the same effect stack and after this opcode are not processed as expected.