### PR TITLE
New EEex Feature: Add deferred lists-resolved hook

### DIFF
--- a/EEex/copy/EEex_scripts/EEex_Opcode.lua
+++ b/EEex/copy/EEex_scripts/EEex_Opcode.lua
@@ -6,9 +6,20 @@
 EEex_Opcode_ListsResolvedListeners = {}
 
 function EEex_Opcode_AddListsResolvedListener(func)
+	-- This legacy listener is called immediately after each engine effect-list
+	-- resolution. High-volume callers, such as item comparison, should use
+	-- EEex_Opcode_AddDeferredListsResolvedListener() instead.
 	-- [EEex.dll]
 	EEex.Opcode_LuaHook_AfterListsResolved_Enabled = true
 	table.insert(EEex_Opcode_ListsResolvedListeners, func)
+end
+
+EEex_Opcode_DeferredListsResolvedListeners = {}
+
+function EEex_Opcode_AddDeferredListsResolvedListener(func)
+	-- [EEex.dll]
+	EEex.Opcode_LuaHook_DeferredAfterListsResolved_Enabled = true
+	table.insert(EEex_Opcode_DeferredListsResolvedListeners, func)
 end
 
 -----------------------
@@ -125,6 +136,12 @@ end
 
 function EEex_Opcode_LuaHook_AfterListsResolved(sprite)
 	for _, func in ipairs(EEex_Opcode_ListsResolvedListeners) do
+		EEex_Utility_TryIgnore(func, sprite)
+	end
+end
+
+function EEex_Opcode_LuaHook_DeferredAfterListsResolved(sprite)
+	for _, func in ipairs(EEex_Opcode_DeferredListsResolvedListeners) do
 		EEex_Utility_TryIgnore(func, sprite)
 	end
 end

--- a/EEex/copy/EEex_scripts/EEex_Opcode_Patch.lua
+++ b/EEex/copy/EEex_scripts/EEex_Opcode_Patch.lua
@@ -81,6 +81,26 @@
 		]]}
 	)
 
+	--[[
+	+--------------------------------------------------------------------------------------------------+
+	| Flush coalesced lists-resolved listeners near the end of the sprite's real AI processing pass    |
+	+--------------------------------------------------------------------------------------------------+
+	|   [EEex.dll] EEex::Opcode_Hook_FlushDeferredAfterListsResolved(pSprite: CGameSprite*)            |
+	+--------------------------------------------------------------------------------------------------+
+	--]]
+
+	EEex_HookBeforeRestoreWithLabels(EEex_Label("Hook-CGameSprite::ProcessAI()-BeforeReturn"), 0, 8, 8, {
+		{"hook_integrity_watchdog_ignore_registers", {
+			EEex_HookIntegrityWatchdogRegister.RAX, EEex_HookIntegrityWatchdogRegister.RCX, EEex_HookIntegrityWatchdogRegister.RDX,
+			EEex_HookIntegrityWatchdogRegister.R8, EEex_HookIntegrityWatchdogRegister.R9, EEex_HookIntegrityWatchdogRegister.R10,
+			EEex_HookIntegrityWatchdogRegister.R11
+		}}},
+		{[[
+			mov rcx, rsi                                  ; pSprite
+			call #L(EEex::Opcode_Hook_FlushDeferredAfterListsResolved)
+		]]}
+	)
+
 	--------------------------------------
 	--          Opcode Changes          --
 	--------------------------------------

--- a/EEex/loader/InfinityLoader.db
+++ b/EEex/loader/InfinityLoader.db
@@ -2372,6 +2372,10 @@ Operations=ADD 51
 Pattern=0FB7974C4B0000
 Operations=ADD 121
 
+[Hook-CGameSprite::ProcessAI()-BeforeReturn]
+Pattern=4C8BBC24680100004C8BAC2460010000
+Operations=ADD 0
+
 [Hook-CGameSprite::ProcessEffectList()-AfterListsResolved-1]
 Pattern=837D8C00
 Operations=ADD 20


### PR DESCRIPTION
This PR implements an alternative listener to the existing `EEex_Opcode_AddListsResolvedListener()` (which is prone to cause stuttering / slowdowns under certain circumstances).

The new deferred listener fires:

- at most once per sprite `ProcessAI()` pass
- only if that sprite had one or more `ProcessEffectList()` resolutions since the previous flush
- never for temporary copied sprites that resolve lists but are destroyed before `ProcessAI()`
- independently from the legacy immediate listener, which still fires on every raw list resolution

So for one active sprite under normal 30 FPS / 15 AI-pass-per-second behavior: expect about 15 deferred callbacks per second max. For 20 active sprites, the upper bound is about `20 * 15` per second, but only for sprites that actually had pending resolved-list work.

Requires: https://github.com/Bubb13/InfinityLoader/pull/10.