### PR TITLE
Engine Fix: Op120 vs. AoE

### DIFF
--- a/EEex/copy/EEex_scripts/EEex_Main.lua
+++ b/EEex/copy/EEex_scripts/EEex_Main.lua
@@ -28,6 +28,7 @@ EEex_Main_Private_StartupFiles = {
 	"EEex_Keybinds",           --
 	"EEex_Menu",               --
 	"EEex_Menu_Patch",         --
+	"EEex_Op120_Patch",        -- Configure opcode 120 before Mix installs its shared Swing hooks
 	"EEex_Mix_Patch",          --
 	"EEex_Object",             --
 	"EEex_Object_Patch",       --

--- a/EEex/copy/EEex_scripts/EEex_Mix_Patch.lua
+++ b/EEex/copy/EEex_scripts/EEex_Mix_Patch.lua
@@ -7,6 +7,16 @@
 
 	EEex_DisableCodeProtection()
 
+	-- Run only on the native ranged delivery branch, after BlockWeaponHit
+	-- listeners have allowed it. The melee branch may hold a cached projectile
+	-- but applies its damage directly; it must keep the original immunity test.
+	local op120RangedImmunity = EEex.Op120Installed and {[[
+		mov edx, eax ; Original CImmunitiesWeapon::OnList result
+		mov rcx, rbx ; Attacking sprite (verified in all three v2.7.3.0 images)
+		call #L(EEex::Op120_Hook_RangedImmunity)
+		mov qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)], rax
+	]]} or {}
+
 	-------------------------------------------------------
 	-- [Lua] EEex_Sprite_Hook_CheckBlockWeaponHit()      --
 	-- [Lua] EEex_Opcode_Hook_OnAfterSwingCheckedOp248() --
@@ -109,6 +119,7 @@
 				#RESUME_SHADOW_ENTRY
 				mov rax, qword ptr ss:[rsp+#SHADOW_SPACE_BOTTOM(-8)]
 			]]},
+			op120RangedImmunity,
 			EEex_GenLuaCall("EEex_Opcode_Hook_OnAfterSwingCheckedOp249", {
 				["labelSuffix"] = "_2",
 				["args"] = {

--- a/EEex/copy/EEex_scripts/EEex_Op120_Patch.lua
+++ b/EEex/copy/EEex_scripts/EEex_Op120_Patch.lua
@@ -1,0 +1,78 @@
+(function()
+
+	-- This export exists only in the v2.7.3.0 build. Older engine versions
+	-- retain their existing hooks and must not look up v2.7-only patterns.
+	if not EEex_TryLabel("EEex::Op120_Hook_Swing") then
+		return
+	end
+
+	local names = {
+		"Op120-Swing", "Op120-AddEffect", "Op120-OnList", "Op120-OverrideWeaponType", "Op120-CopySelective",
+		"Op120-FireArea", "Op120-FireColorSpray", "Op120-FireConeOfCold", "Op120-FireNewScorcher",
+		"Op120-FireChain", "Op120-FireFall", "Op120-FireMulti", "Op120-AIUpdateBAM", "Op120-CaptureWeaponCall",
+		"Op120-RangedImmunityCall", "Op120-MeleeImmunityCall",
+		"Op120-ApplyCriticals", "Op120-RangedCriticalsCall", "EEex::Op120_ApplyCriticals", "EEex::Op120_Hook_ApplyCriticals",
+		"EEex::Op120_Hook_Swing", "EEex::Op120_Hook_AddEffect", "EEex::Op120_Hook_CaptureWeapon",
+		"EEex::Op120_Hook_RangedImmunity", "EEex::Op120_Original_Swing", "EEex::Op120_Original_AddEffect",
+		"EEex::Op120_OnList", "EEex::Op120_OverrideWeaponType", "EEex::Op120_CopySelective",
+		"EEex::Op120_MultiTargetFire", "EEex::Op120_FireMulti", "EEex::Op120_AIUpdateBAM",
+	}
+	local addresses = {}
+	for _, name in ipairs(names) do
+		-- Resolve the entire group before modifying code or native pointer slots.
+		addresses[name] = EEex_Label(name)
+	end
+	local criticalsCall = addresses["Op120-RangedCriticalsCall"]
+	if EEex_ReadU8(criticalsCall) ~= 0xE8
+		or criticalsCall + 5 + EEex_Read32(criticalsCall + 1) ~= addresses["Op120-ApplyCriticals"]
+	then
+		EEex_Error("Opcode 120: unexpected ranged critical-hit call")
+	end
+
+	local captureCall = addresses["Op120-CaptureWeaponCall"]
+	if EEex_ReadU8(captureCall) ~= 0xE8
+		or captureCall + 5 + EEex_Read32(captureCall + 1) ~= addresses["Op120-OverrideWeaponType"]
+	then
+		EEex_Error("Opcode 120: unexpected weapon identification call")
+	end
+
+	-- Mix owns these sites. Independently derived v2.7 signatures must agree
+	-- with its labels, so no second detour can accidentally overwrite Mix.
+	for _, kind in ipairs({ "Ranged", "Melee" }) do
+		local site = addresses["Op120-"..kind.."ImmunityCall"]
+		if site ~= EEex_Label("Hook-CGameSprite::Swing()-CImmunitiesWeapon::OnList()-"..kind)
+			or EEex_ReadU8(site) ~= 0xE8
+			or site + 5 + EEex_Read32(site + 1) ~= addresses["Op120-OnList"]
+		then
+			EEex_Error("Opcode 120: unexpected "..kind.." immunity hook")
+		end
+	end
+
+	for _, suffix in ipairs({ "OnList", "OverrideWeaponType", "CopySelective", "FireMulti", "AIUpdateBAM", "ApplyCriticals" }) do
+		EEex_WritePtr(addresses["EEex::Op120_"..suffix], addresses["Op120-"..suffix])
+	end
+	for i, suffix in ipairs({ "Area", "ColorSpray", "ConeOfCold", "NewScorcher", "Chain", "Fall" }) do
+		EEex_WritePtr(addresses["EEex::Op120_MultiTargetFire"] + (i - 1) * EEex_PtrSize, addresses["Op120-Fire"..suffix])
+	end
+
+	EEex_DisableCodeProtection()
+
+	-- The audit verifies that each entry starts with one five-byte non-relative
+	-- MOV, with no interior branch target. The preserved trampoline restores
+	-- that MOV and jumps into the original function; native C++ wrappers own
+	-- the complete Win64 argument/return ABI (including AddEffect's fifth arg).
+	for _, suffix in ipairs({ "Swing", "AddEffect" }) do
+		local originalLabel = "Op120-Original-"..suffix
+		EEex_HookReplaceFunctionMaintainOriginal(addresses["Op120-"..suffix], 5, originalLabel, addresses["EEex::Op120_Hook_"..suffix])
+		EEex_WritePtr(addresses["EEex::Op120_Original_"..suffix], EEex_Label(originalLabel))
+	end
+
+	-- An ABI-identical call replacement captures the fifth stack argument
+	-- without hand-copying it in assembly, then invokes the native routine.
+	EEex_ReplaceCall(captureCall, addresses["EEex::Op120_Hook_CaptureWeapon"])
+	EEex_ReplaceCall(criticalsCall, addresses["EEex::Op120_Hook_ApplyCriticals"])
+	EEex.Op120Installed = true
+
+	EEex_EnableCodeProtection()
+
+end)()

--- a/EEex/loader/v2.7.3.0/pattern_dbs/v2.7.3.0.db
+++ b/EEex/loader/v2.7.3.0/pattern_dbs/v2.7.3.0.db
@@ -38,3 +38,77 @@ Operations=ADD 17
 [Hook-drawItem()-FixForcedScrollbarDivideByZero2]
 Pattern=8B5DDC488D55E0
 Operations=ADD 10
+
+; Opcode 120 (engine fix)
+
+[Op120-Swing]
+Pattern=66894594
+Operations=ADD -122
+
+[Op120-AddEffect]
+Pattern=41384215
+Operations=ADD -95
+
+[Op120-OnList]
+Pattern=0FB72A
+Operations=ADD -44
+
+[Op120-OverrideWeaponType]
+Pattern=488B368B03
+Operations=ADD -68
+
+[Op120-CopySelective]
+Pattern=B930000000488B3F
+Operations=ADD -100
+
+[Op120-ApplyCriticals]
+Pattern=49394D18
+Operations=ADD -104
+
+[Op120-FireArea]
+Pattern=FF90D80000004883C440
+Operations=ADD -64
+
+[Op120-FireColorSpray]
+Pattern=0FB7457F488BF9
+Operations=ADD -42
+
+[Op120-FireConeOfCold]
+Pattern=83F9F6
+Operations=ADD -102
+
+[Op120-FireNewScorcher]
+Pattern=89BBD0040000
+Operations=ADD -58
+
+[Op120-FireChain]
+Pattern=488BB180000000
+Operations=ADD -30
+
+[Op120-FireFall]
+Pattern=488B018BF3
+Operations=ADD -81
+
+[Op120-FireMulti]
+Pattern=C3488D55DF
+Operations=ADD -85
+
+[Op120-AIUpdateBAM]
+Pattern=418BDD84C0
+Operations=ADD -124
+
+[Op120-RangedCriticalsCall]
+Pattern=894C24484C8BC6
+Operations=ADD -43
+
+[Op120-CaptureWeaponCall]
+Pattern=0FBF1403
+Operations=ADD -121
+
+[Op120-RangedImmunityCall]
+Pattern=458BCD4C8BC7
+Operations=ADD 83
+
+[Op120-MeleeImmunityCall]
+Pattern=458BCD4D8BC4
+Operations=ADD 126


### PR DESCRIPTION
# Opcode `#120` (`0x78`) Immunity to Weapons

> [!WARNING]
> **Known bug:** AoE projectiles (e.g. Arrow of Detonation) only check for Weapon Immunity on the attacked target, and use that result for all targets caught within their area of effect.

> [!TIP]
> **Fix:** Weapon Immunity is now checked per recipient at delivery, using captured launch weapon data.

**Notes:**
- Tested on iwd:ee `v2.7.3.0`
- See also: https://github.com/Bubb13/InfinityLoader/pull/18